### PR TITLE
previous merge broke it for ruby 1.8

### DIFF
--- a/lib/fedex/request/label.rb
+++ b/lib/fedex/request/label.rb
@@ -11,9 +11,9 @@ module Fedex
         requires!(options, :filename)
         @filename = options[:filename]
         @label_specification = {
-          label_format_type: 'COMMON2D',
-          image_type: 'PDF',
-          label_stock_type: 'PAPER_LETTER'
+          :label_format_type => 'COMMON2D',
+          :image_type => 'PDF',
+          :label_stock_type => 'PAPER_LETTER'
         }
         @label_specification.merge!(options[:label_specification]) if options[:label_specification]
       end


### PR DESCRIPTION
Just changing hash syntax, it was breaking on ruby 1.8, i _guess_ this still works on 1.9 since other hashes use this syntax
