### PR TITLE
specify label element ordering - ruby1.8 doesn't maintain hash ordering

### DIFF
--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -59,7 +59,9 @@ module Fedex
       # Add the label specification
       def add_label_specification(xml)
         xml.LabelSpecification {
-          hash_to_xml(xml, @label_specification)
+          xml.LabelFormatType @label_specification[:label_format_type]
+          xml.ImageType @label_specification[:image_type]
+          xml.LabelStockType @label_specification[:label_stock_type]
         }
       end
 


### PR DESCRIPTION
Ruby didn't always return the hash in the initial order causing an issue with the sequence.  Specify ordering in the XML to resolve this issue.  
