### PR TITLE
Improve exception details

### DIFF
--- a/lib/fedex/request/address.rb
+++ b/lib/fedex/request/address.rb
@@ -23,7 +23,7 @@ module Fedex
           error_message = if response[:address_validation_reply]
             [response[:address_validation_reply][:notifications]].flatten.first[:message]
           else
-            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"]}"
+            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n--#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"].join("\n--")}"
           end rescue $1
           raise RateError, error_message
         end

--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -15,7 +15,7 @@ module Fedex
           error_message = if response[:rate_reply]
             [response[:rate_reply][:notifications]].flatten.first[:message]
           else
-            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"]}"
+            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n--#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"].join("\n--")}"
           end rescue $1
           raise RateError, error_message
         end

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -70,7 +70,7 @@ module Fedex
         error_message = if response[:process_shipment_reply]
           [response[:process_shipment_reply][:notifications]].flatten.first[:message]
         else
-          "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"]}"
+          "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n--#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"].join("\n--")}"
         end rescue $1
         raise RateError, error_message
       end

--- a/lib/fedex/request/tracking_information.rb
+++ b/lib/fedex/request/tracking_information.rb
@@ -37,7 +37,7 @@ module Fedex
           error_message = if response[:track_reply]
             response[:track_reply][:notifications][:message]
           else
-            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"]}"
+            "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n--#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"].join("\n--")}"
           end rescue $1
           raise RateError, error_message
         end


### PR DESCRIPTION
Validation errors shown by 21551a838ed36f12a45892b4da273ddddfb40472 can be a bit hard to read, just adding new lines so it's easier to tell where 1 error starts and the other begins

This is what it looks like with this, instead of the array output

![Screen Shot 2013-02-22 at 11 21 28 AM](https://f.cloud.github.com/assets/139916/186227/1b14de5c-7d25-11e2-9d14-ae4c596edf1c.png)
