### PR TITLE
Allow customer references to have arbitrary type

### DIFF
--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -174,14 +174,7 @@ module Fedex
                 xml.Units package[:dimensions][:units]
               }
             end
-            if package[:customer_refrences]
-              xml.CustomerReferences{
-              package[:customer_refrences].each do |value|
-                 xml.CustomerReferenceType 'CUSTOMER_REFERENCE'
-                 xml.Value                 value
-              end
-              }
-            end
+            add_customer_references(xml, package)
             if package[:special_services_requested] && package[:special_services_requested][:special_service_types]
               xml.SpecialServicesRequested{
                 if package[:special_services_requested][:special_service_types].is_a? Array
@@ -227,6 +220,29 @@ module Fedex
                 end
               }
             end
+          }
+        end
+      end
+
+      def add_customer_references(xml, package)
+        # customer_refrences is a legacy misspelling
+        if refs = package[:customer_references] || package[:customer_refrences]
+          xml.CustomerReferences{
+          refs.each do |ref|
+            if ref.is_a?(Hash)
+              # :type can specify custom type:
+              #
+              # BILL_OF_LADING, CUSTOMER_REFERENCE, DEPARTMENT_NUMBER,
+              # ELECTRONIC_PRODUCT_CODE, INTRACOUNTRY_REGULATORY_REFERENCE,
+              # INVOICE_NUMBER, P_O_NUMBER, RMA_ASSOCIATION,
+              # SHIPMENT_INTEGRITY, STORE_NUMBER
+              xml.CustomerReferenceType ref[:type]
+              xml.Value                 ref[:value]
+            else
+              xml.CustomerReferenceType 'CUSTOMER_REFERENCE'
+              xml.Value                 ref
+            end
+          end
           }
         end
       end


### PR DESCRIPTION
Current `fedex` code sends any customer reference numbers to FedEx with the `CUSTOMER_REFERENCE` type. But FedEx supports more types, including `RMA_ASSOCIATION` which we happened to need.

This code allows any entry in the `customer_references` array to be a Hash with `:type` and `:value` entries, which will be passed through to FedEx Web Services as `CustomerReferenceType` and `Value`. The old syntax is still supported and has the same behavior -- the default type is `CUSTOMER_REFERENCE`.

Example of the new usage:

``` ruby
shipping.label(
  format: 'pdf',
  filename: 'label.pdf',
  # ...
  packages: [
    {
      weight: {value: 1, units: 'LB'},
      customer_references: [
        "Order #12345", # default is CUSTOMER_REFERENCE
        {type: 'RMA_ASSOCIATION', value: 'RA_2468'} # custom type
      ]
    }
  ]
)
```

Also, this commit enables the correct spelling `customer_reference` while still supporting the old `customer_refrence`.

Thanks for the fedex gem; it is very helpful!
