### PR TITLE
expose all tracking details

### DIFF
--- a/lib/fedex/tracking_information.rb
+++ b/lib/fedex/tracking_information.rb
@@ -29,7 +29,7 @@ module Fedex
     }
 
     attr_reader :tracking_number, :signature_name, :service_type, :status,
-                :delivery_at, :events, :unique_tracking_number
+                :delivery_at, :events, :unique_tracking_number, :details
 
     def initialize(details = {})
       @details = details


### PR DESCRIPTION
I wanted some more tracking details attributes and rather than create a bunch more variables I just exposed @details and now I have all of the info I wanted.
