### PR TITLE
Add Insured Value field to the package line items definition

### DIFF
--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -177,6 +177,12 @@ module Fedex
         @packages.each do |package|
           xml.RequestedPackageLineItems{
             xml.GroupPackageCount 1
+            if package[:insured_value]
+              xml.InsuredValue{
+                xml.Currency package[:insured_value][:currency]
+                xml.Amount package[:insured_value][:amount]
+              }
+            end
             xml.Weight{
               xml.Units package[:weight][:units]
               xml.Value package[:weight][:value]


### PR DESCRIPTION
We just faced a troubles passing FedEx certification for the shipment service API because of empty Carriage Value field, so, here it is :)

This only present on the international labels.

```
packages << {
  :weight => { :units => "LB", :value => 2.425082 },
  :insured_value => { :currency => 'UKL', :amount => 100 }
}
```

![label pdf__ _1__3_](https://f.cloud.github.com/assets/62760/1225365/ebaa1bd8-2764-11e3-90d0-e1dc719640be.png)
