### PR TITLE
Use :address instead of :street for address validation request

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -212,7 +212,7 @@ To verify an address is valid and deliverable:
 ```ruby
 
 address = {
-  :street      => "5 Elm Street",
+  :address     => "5 Elm Street",
   :city        => "Norwalk",
   :state       => "CT",
   :postal_code => "06850",

--- a/lib/fedex/request/address.rb
+++ b/lib/fedex/request/address.rb
@@ -9,6 +9,8 @@ module Fedex
         requires!(options, :address)
         @credentials = credentials
         @address     = options[:address]
+
+        @address[:address] ||= @address[:street]
       end
 
       def process_request
@@ -69,7 +71,7 @@ module Fedex
         xml.AddressesToValidate{
           xml.CompanyName           @address[:company] unless @address[:company].nil? or @address[:company].empty?
           xml.Address{
-            Array(@address[:street]).take(2).each do |address_line|
+            Array(@address[:address]).take(2).each do |address_line|
               xml.StreetLines address_line
             end
             xml.City                @address[:city]

--- a/spec/lib/fedex/address_spec.rb
+++ b/spec/lib/fedex/address_spec.rb
@@ -11,7 +11,7 @@ module Fedex
       context "valid address", :vcr do
         let(:address) do
           {
-            :street      => "5 Elm Street",
+            :address     => "5 Elm Street",
             :city        => "Norwalk",
             :state       => "CT",
             :postal_code => "06850",
@@ -37,7 +37,7 @@ module Fedex
       context "multiple address validation results", :vcr do
         let(:address) do
           {
-            :street      => "301 Las Colinas Blvd",
+            :address     => "301 Las Colinas Blvd",
             :city        => "Irving",
             :state       => "TX",
             :postal_code => "75039",


### PR DESCRIPTION
Address validation requests use and :street key while other request use an :address key for street lines. I updated the address validation request to more closely match the others.
