### PR TITLE
Add payment_information attributes on a shipment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ spec/vcr
 *.bbprojectd
 .DS_Store
 hacks
+.ruby-version

--- a/Readme.md
+++ b/Readme.md
@@ -68,12 +68,26 @@ packages << {
 ```
 
 By default packaging type is "YOUR PACKAGING" and the drop off type is "REGULAR PICKUP".
-If you need something different you can pass an extra hash for shipping options
+If you need something different you can pass an extra hash for shipping options.
 
 ```ruby
 shipping_options = {
   :packaging_type => "YOUR_PACKAGING",
   :drop_off_type => "REGULAR_PICKUP"
+}
+```
+
+By default the shipping charges will be assigned to the sender. If you may
+change this by passing an extra hash of payment options.
+
+```ruby
+payment_options = {
+  :type => "THIRD_PARTY",
+  :account_number => "123456789"
+  :name => "Third Party Payor",
+  :company => "Company",
+  :phone_number => "555-555-5555",
+  :country_code => "US"
 }
 ```
 


### PR DESCRIPTION
The current implementation defaults the payment information to the sender, but
in my project I need the ability to customize the payment information to the
recipient or a third party. If payment_information is not provided to the
shipment, it will default to the current behavior.
