### PR TITLE
Added a missing comma to code example within README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ change this by passing an extra hash of payment options.
 ```ruby
 payment_options = {
   :type => "THIRD_PARTY",
-  :account_number => "123456789"
+  :account_number => "123456789",
   :name => "Third Party Payor",
   :company => "Company",
   :phone_number => "555-555-5555",


### PR DESCRIPTION
The `payment_options` hash within the README was missing a comma after the `account_number` attribute.  I noticed this because I tried to copy and paste the code directly into my terminal and received an error.  To fix this I simply added the necessary comma.
