### PR TITLE
Enable MPS (Multi Piece Shipment) labels.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,6 +189,44 @@ shipment.save!
 
 Documentation for setting up Paperclip with Amazon S3 can be found in the Paperclip [README](https://github.com/thoughtbot/paperclip/#storage).
 
+### ** Generate shipping labels for multi-package shipments (MPS) **
+
+Multiple packages for a single pick-up, destination and payer can be combined into a single MPS shipment. The first label will provide a master tracking number which must be used in the subsequent calls for the remaining packages in the shipment.
+
+Parameters for the first label:
+```ruby
+label = fedex.label(
+  :filename => file_name,
+  :shipper => shipper,
+  :recipient => recipient,
+  :packages => packages,
+  :service_type => service_type,
+  :shipping_details => shipping_details,
+  :shipping_charges_payment => shipping_charges_payment,
+  :customs_clearance_detail => customs_clearance_detail,
+  :mps => {:package_count => package_count, :total_weight => total_weight, :sequence_number => '1'}
+  )
+```
+
+Parameters for labels 2 through 'n':
+```ruby
+fedex.label(
+  :filename => file_name,
+  :shipper => shipper,
+  :recipient => recipient,
+  :packages => packages,
+  :service_type => service_type,
+  :shipping_details => shipping_details,
+  :shipping_charges_payment => shipping_charges_payment,
+  :customs_clearance_detail => customs_clearance_detail,
+  :mps => {
+      :master_tracking_id => {:tracking_id_type => 'FEDEX', :tracking_number =>tracking_number},
+      :package_count => package_count,
+      :total_weight => total_weight,
+      :sequence_number => 'n'
+      }
+   )
+```
 
 ### ** Tracking a shipment **
 

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -41,6 +41,7 @@ module Fedex
           xml.DropoffType @shipping_options[:drop_off_type] ||= "REGULAR_PICKUP"
           xml.ServiceType service_type
           xml.PackagingType @shipping_options[:packaging_type] ||= "YOUR_PACKAGING"
+          add_total_weight(xml) if @mps.has_key? :total_weight
           add_shipper(xml)
           add_recipient(xml)
           add_shipping_charges_payment(xml)
@@ -50,6 +51,15 @@ module Fedex
           xml.RateRequestTypes "ACCOUNT"
           add_packages(xml)
         }
+      end
+
+      def add_total_weight(xml)
+        if @mps.has_key? :total_weight
+          xml.TotalWeight{
+            xml.Units @mps[:total_weight][:units]
+            xml.Value @mps[:total_weight][:value]
+          }
+        end
       end
 
       # Hook that can be used to add custom parts.


### PR DESCRIPTION
In order to request MPS labels we need to provide a package count & total packages weight when requesting the initial label. Initial label provides us with a Master Tracking Number which must be included when requesting labels for each of the additional packages.
