### PR TITLE
downgraded dependency version

### DIFF
--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '~> 0.13.0'
-  s.add_dependency 'nokogiri',            '~> 1.6.0'
+  s.add_dependency 'httparty',            '>= 0.8.3'
+  s.add_dependency 'nokogiri',            '>= 1.5.6'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'
   s.add_development_dependency 'vcr',     '~> 2.0.0'


### PR DESCRIPTION
Downgraded version of nokogiri and httparty. Works perfectly with older version of nokogiri and httparty. Will allow more users to use the gem without upgrading these gems. It would help to easily follow development.
