### PR TITLE
fix incorrect spelling of occurred

### DIFF
--- a/lib/fedex/tracking_information/event.rb
+++ b/lib/fedex/tracking_information/event.rb
@@ -1,13 +1,15 @@
 module Fedex
   class TrackingInformation
     class Event
-      attr_reader :description, :type, :occured_at, :city, :state, :postal_code,
+      attr_reader :description, :type, :occurred_at, :city, :state, :postal_code,
                   :country, :residential, :exception_code, :exception_description
+
+      alias_method :occured_at, :occurred_at
 
       def initialize(details = {})
         @description           = details[:event_description]
         @type                  = details[:event_type]
-        @occured_at            = Time.parse(details[:timestamp])
+        @occurred_at            = Time.parse(details[:timestamp])
         @city                  = details[:address][:city]
         @state                 = details[:address][:state_or_province_code]
         @postal_code           = details[:address][:postal_code]
@@ -16,6 +18,7 @@ module Fedex
         @exception_code        = details[:status_exception_code]
         @exception_description = details[:status_exception_description]
       end
+
     end
   end
 end


### PR DESCRIPTION
occured_at was spelled wrong. This will not break any calls to the incorrect spelling.
