### PR TITLE
Adds shipping option flag for Saturday delivery

### DIFF
--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -46,7 +46,7 @@ module Fedex
           add_shipper(xml)
           add_recipient(xml)
           add_shipping_charges_payment(xml)
-          add_special_services(xml) if @shipping_options[:return_reason] || @shipping_options[:cod]
+          add_special_services(xml) if @shipping_options[:return_reason] || @shipping_options[:cod] || @shipping_options[:saturday_delivery]
           add_customs_clearance(xml) if @customs_clearance_detail
           add_custom_components(xml)
           xml.RateRequestTypes "ACCOUNT"
@@ -98,6 +98,9 @@ module Fedex
               }
               xml.CollectionType @shipping_options[:cod][:collection_type] if @shipping_options[:cod][:collection_type]
             }
+          end
+          if @shipping_options[:saturday_delivery]
+            xml.SpecialServiceTypes "SATURDAY_DELIVERY"
           end
         }
       end


### PR DESCRIPTION
My attempt at implementing Saturday delivery upgrades as mentioned in https://github.com/jazminschroeder/fedex/issues/91 

If it's already implemented and I missed it, or if you have any opinions on cleaning up the code, please let me know.