### PR TITLE
Change pickup service id to 'disp'

### DIFF
--- a/lib/fedex/request/pickup.rb
+++ b/lib/fedex/request/pickup.rb
@@ -48,7 +48,7 @@ module Fedex
       end
 
       def service
-        { :id => 'pickup', :version => Fedex::PICKUP_API_VERSION }
+        { :id => 'disp', :version => Fedex::PICKUP_API_VERSION }
       end
 
       # Add shipper to xml request

--- a/lib/fedex/request/pickup_availability.rb
+++ b/lib/fedex/request/pickup_availability.rb
@@ -47,7 +47,7 @@ module Fedex
       end
 
       def service
-        { :id => 'pickup', :version => Fedex::PICKUP_API_VERSION }
+        { :id => 'disp', :version => Fedex::PICKUP_API_VERSION }
       end
 
       def add_pickup_address(xml)


### PR DESCRIPTION
Fixes #94

Hi there!
After reading through the FedEx docs and trying to get the pickup availability request to work, I saw that the service id for pickups is `disp` rather than `pickup`, so I just thought I'd change it. I also noticed later that there is an open issue about this.

Cheers!