### PR TITLE
add printed_label_origin option to shipment request

### DIFF
--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -51,6 +51,7 @@ module Fedex
         requires!(options, :shipper, :recipient, :packages)
         @credentials = credentials
         @shipper, @recipient, @packages, @service_type, @customs_clearance_detail, @debug = options[:shipper], options[:recipient], options[:packages], options[:service_type], options[:customs_clearance_detail], options[:debug]
+        @origin = options[:origin]
         @debug = ENV['DEBUG'] == 'true'
         @shipping_options =  options[:shipping_options] ||={}
         @payment_options = options[:payment_options] ||={}
@@ -138,6 +139,26 @@ module Fedex
             xml.StateOrProvinceCode @shipper[:state]
             xml.PostalCode @shipper[:postal_code]
             xml.CountryCode @shipper[:country_code]
+          }
+        }
+      end
+
+      # Add shipper to xml request
+      def add_origin(xml)
+        xml.Origin{
+          xml.Contact{
+            xml.PersonName @origin[:name]
+            xml.CompanyName @origin[:company]
+            xml.PhoneNumber @origin[:phone_number]
+          }
+          xml.Address {
+            Array(@origin[:address]).take(2).each do |address_line|
+              xml.StreetLines address_line
+            end
+            xml.City @origin[:city]
+            xml.StateOrProvinceCode @origin[:state]
+            xml.PostalCode @origin[:postal_code]
+            xml.CountryCode @origin[:country_code]
           }
         }
       end

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -44,6 +44,7 @@ module Fedex
           xml.PackagingType @shipping_options[:packaging_type] ||= "YOUR_PACKAGING"
           add_total_weight(xml) if @mps.has_key? :total_weight
           add_shipper(xml)
+          add_origin(xml) if @origin
           add_recipient(xml)
           add_shipping_charges_payment(xml)
           add_special_services(xml) if @shipping_options[:return_reason] || @shipping_options[:cod] || @shipping_options[:saturday_delivery]


### PR DESCRIPTION
I'd prefer to have a test for this, but the `:customer_specified_detail` option isn't tested either and there's no confirmation in the `response` of the server receiving that element other than then the label.  

Seems like we need some request specs to make sure the `build_xml` is sending the correct XML, but that'll take some more time.