### PR TITLE
Add estimated delivery timestamp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,10 +68,10 @@ packages << {
 ```
 
 By default packaging type is "YOUR PACKAGING" and the drop off type is "REGULAR PICKUP".
-If you need something different you can pass an extra hash for shipping details
+If you need something different you can pass an extra hash for shipping options
 
 ```ruby
-shipping_details = {
+shipping_options = {
   :packaging_type => "YOUR_PACKAGING",
   :drop_off_type => "REGULAR_PICKUP"
 }
@@ -98,7 +98,7 @@ rate = fedex.rate(:shipper=>shipper,
                   :recipient => recipient,
                   :packages => packages,
                   :service_type => "FEDEX_GROUND",
-                  :shipping_details => shipping_details)
+                  :shipping_options => shipping_options)
 ```
 
 Fedex provides multiple total values; `total_net_charge` is the final amount you are looking for.
@@ -123,7 +123,7 @@ ship = fedex.ship(:shipper=>shipper,
                   :recipient => recipient,
                   :packages => packages,
                   :service_type => "FEDEX_GROUND",
-                  :shipping_details => shipping_details)
+                  :shipping_options => shipping_options)
 puts ship[:completed_shipment_detail][:operational_detail] [:transit_time]
 ```
 Above code will give you the transit time.
@@ -138,7 +138,7 @@ label = fedex.label(:filename => "my_dir/example.pdf",
                     :recipient => recipient,
                     :packages => packages,
                     :service_type => "FEDEX_GROUND",
-                    :shipping_details => shipping_details)
+                    :shipping_options => shipping_options)
 ```
 
 ### ** Generate a shipping label in any available format **
@@ -156,7 +156,7 @@ label = fedex.label(:filename => "my_dir/example_epl2.pcx",
                     :recipient => recipient,
                     :packages => packages,
                     :service_type => "FEDEX_GROUND",
-                    :shipping_details => shipping_details,
+                    :shipping_options => shipping_options,
                     :label_specification => example_spec)
 ```
 ### ** Storing a label on Amazon S3 with Paperclip **
@@ -169,7 +169,7 @@ label = fedex.label(:filename => "tmp/example_label.pdf",
                     :recipient => recipient,
                     :packages => packages,
                     :service_type => "FEDEX_GROUND",
-                    :shipping_details => shipping_details,
+                    :shipping_options => shipping_options,
                     :label_specification => example_spec)
 ```
 

--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "fedex"
 
-  s.add_dependency 'httparty',            '~> 0.10.0'
+  s.add_dependency 'httparty',            '~> 0.11.0'
   s.add_dependency 'nokogiri',            '~> 1.5.0'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'

--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "fedex"
 
   s.add_dependency 'httparty',            '~> 0.11.0'
-  s.add_dependency 'nokogiri',            '~> 1.5.0'
+  s.add_dependency 'nokogiri',            '~> 1.6.0'
 
   s.add_development_dependency "rspec",   '~> 2.9.0'
   s.add_development_dependency 'vcr',     '~> 2.0.0'

--- a/lib/fedex/request/address.rb
+++ b/lib/fedex/request/address.rb
@@ -17,7 +17,7 @@ module Fedex
         response = parse_response(api_response)
         if success?(response)
           options = response[:address_validation_reply][:address_results][:proposed_address_details]
-
+          options = options.first if options.is_a? Array
           Fedex::Address.new(options)
         else
           error_message = if response[:address_validation_reply]

--- a/lib/fedex/request/shipment.rb
+++ b/lib/fedex/request/shipment.rb
@@ -37,7 +37,7 @@ module Fedex
       # Add information for shipments
       def add_requested_shipment(xml)
         xml.RequestedShipment{
-          xml.ShipTimestamp Time.now.utc.iso8601(2)
+          xml.ShipTimestamp @shipping_options[:ship_timestamp] ||= Time.now.utc.iso8601(2)
           xml.DropoffType @shipping_options[:drop_off_type] ||= "REGULAR_PICKUP"
           xml.ServiceType service_type
           xml.PackagingType @shipping_options[:packaging_type] ||= "YOUR_PACKAGING"

--- a/lib/fedex/tracking_information.rb
+++ b/lib/fedex/tracking_information.rb
@@ -29,7 +29,7 @@ module Fedex
     }
 
     attr_reader :tracking_number, :signature_name, :service_type, :status,
-                :delivery_at, :events, :unique_tracking_number
+                :delivery_at, :events, :unique_tracking_number, :estimated_delivery_at
 
     def initialize(details = {})
       @details = details
@@ -42,6 +42,10 @@ module Fedex
 
       if details.has_key?(:actual_delivery_timestamp)
         @delivery_at = Time.parse(details[:actual_delivery_timestamp])
+      end
+
+      if details.has_key?(:estimated_delivery_timestamp)
+        @estimated_delivery_at = Time.parse(details[:estimated_delivery_timestamp])
       end
 
       @events = [details[:events]].flatten.compact.map do |event_details|

--- a/spec/lib/fedex/address_spec.rb
+++ b/spec/lib/fedex/address_spec.rb
@@ -34,6 +34,26 @@ module Fedex
         end
       end
 
+      context "multiple address validation results", :vcr do
+        let(:address) do
+          {
+            :street      => "301 Las Colinas Blvd",
+            :city        => "Irving",
+            :state       => "TX",
+            :postal_code => "75039",
+            :country     => "USA"
+          }
+        end
+
+        let(:options) do
+          { :address => address }
+        end
+
+        it "validates the address" do
+          expect{ fedex.validate_address(options) }.to_not raise_error
+        end
+      end
+
     end
   end
 end

--- a/spec/lib/fedex/track_spec.rb
+++ b/spec/lib/fedex/track_spec.rb
@@ -44,7 +44,7 @@ module Fedex
       it "reports the status of the package" do
         tracking_info = fedex.track(options.merge(:uuid => uuid)).first
 
-        tracking_info.status.should == "In transit"
+        tracking_info.status.should == "Shipment cancelled by sender"
       end
 
     end


### PR DESCRIPTION
For [this PR](https://github.com/stitchfix/fashionthing/pull/980) in FashionThing, I added an `estimated_delivery_at` variable that can be accessed from the Fedex::TrackingInformation class.

I can't get all the specs in lib/fedex/track_spec.rb to pass though so not sure if I need to do anything special.

It's also pulling in a lot of old commits...

@davetron5000 @jonathandean 



