### PR TITLE
Fedex::RateError Issue - Solved

### DIFF
--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -372,7 +372,7 @@ module Fedex
 
       # Parse response, convert keys to underscore symbols
       def parse_response(response)
-        response = sanitize_response_keys(response)
+        response = sanitize_response_keys(response.parsed_response)
       end
 
       # Recursively sanitizes the response object by cleaning up any hash keys.


### PR DESCRIPTION
Solved an issue with parsing of HTTP Party response.

``` json
#<HTTParty::Response:0x10af6a8 parsed_response={  ... }}
```

Because the data in response comes in parsed_response object there was an error in parsing the HTTP Party response data and always showed the Rate error for any of the methods used.
