### PR TITLE
Fix HTTParty parsed_response to allow updates

### DIFF
--- a/fedex.gemspec
+++ b/fedex.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'httparty',            '>= 0.8.3'
+  s.add_dependency 'httparty',            '>= 0.14.0'
   s.add_dependency 'nokogiri',            '>= 1.5.6'
 
   s.add_development_dependency "rspec",   '~> 3.0.0'

--- a/lib/fedex/request/base.rb
+++ b/lib/fedex/request/base.rb
@@ -349,7 +349,7 @@ module Fedex
 
       # Parse response, convert keys to underscore symbols
       def parse_response(response)
-        response = sanitize_response_keys(response)
+        response = sanitize_response_keys(response.parsed_response)
       end
 
       # Recursively sanitizes the response object by cleaning up any hash keys.


### PR DESCRIPTION
This is a duplicate of https://github.com/jazminschroeder/fedex/pull/124 but I incorporated @jaysonvirissimo's comment so that we can make progress on this.

We'd love to use this update without having to fork this gem.