### PR TITLE
Fix - Show CSRError if its occur when user hit for rate api

### DIFF
--- a/lib/fedex/request/rate.rb
+++ b/lib/fedex/request/rate.rb
@@ -21,6 +21,8 @@ module Fedex
         else
           error_message = if response[:rate_reply]
             [response[:rate_reply][:notifications]].flatten.first[:message]
+          elsif api_response["CSRError"]
+            api_response['CSRError']['exceptionId'] + "::" + api_response['CSRError']['message']
           else
             "#{api_response["Fault"]["detail"]["fault"]["reason"]}\n--#{api_response["Fault"]["detail"]["fault"]["details"]["ValidationFailureDetail"]["message"].join("\n--")}"
           end rescue $1


### PR DESCRIPTION
- If we get CSRError from FedEx, The gem wasn't showing any error, it was just showing `Fedex::RateError`, We should show a proper error message to the user. so he can have an idea what's wrong with the request.

I added one elsif for showing an error message which will help the user to get an exact error from FedEx.